### PR TITLE
Fix VehicleAllocationSettings docstring

### DIFF
--- a/activitysim/abm/models/vehicle_allocation.py
+++ b/activitysim/abm/models/vehicle_allocation.py
@@ -87,7 +87,7 @@ def get_skim_dict(network_los: los.Network_LOS, choosers: pd.DataFrame):
 
 class VehicleAllocationSettings(LogitComponentSettings, extra="forbid"):
     """
-    Settings for the `joint_tour_scheduling` component.
+    Settings for the `vehicle_allocation` component.
     """
 
     preprocessor: PreprocessorSettings | None = None


### PR DESCRIPTION
## Summary
- update VehicleAllocationSettings docstring

## Testing
- `ruff check activitysim/abm/models/vehicle_allocation.py`
- `pytest activitysim/abm/models/vehicle_allocation.py::VehicleAllocationSettings -q` *(fails: ModuleNotFoundError: No module named 'tables')*